### PR TITLE
Add marginaccount info

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -187,6 +187,7 @@ export class MarginAccount {
   borrows!: number[];
   beingLiquidated!: boolean;
   hasBorrows!: boolean;
+  info!: number[];
 
   openOrders!: PublicKey[];
   openOrdersAccounts: (OpenOrders | undefined)[]  // undefined if an openOrdersAccount not yet initialized and has zeroKey


### PR DESCRIPTION
Adds info property so that MarginAccount names can be displayed. See https://github.com/blockworks-foundation/mango-ui-v2/pull/44 for context.